### PR TITLE
Properly handle WinRM listeners

### DIFF
--- a/providers/listener.rb
+++ b/providers/listener.rb
@@ -18,13 +18,85 @@
 # limitations under the License.
 #
 
+include Chef::DSL::RegistryHelper
+
 use_inline_resources
 
 def whyrun_supported?
   true
 end
 
+def load_current_resource
+  return unless registry_key_exists? new_resource.key_name
+
+  @current_resource = Chef::Resource::WinrmConfigListener.new(new_resource.name, run_context)
+  @current_resource.address new_resource.address
+  @current_resource.transport new_resource.transport
+
+  data = registry_hash_values new_resource.key_name
+  @current_resource.port(data['Port'])
+  @current_resource.enabled(data['enabled'] == 1)
+  @current_resource.hostname(data['hostname'])
+  @current_resource.url_prefix(data['uriprefix'])
+  @current_resource.certificate_thumbprint(data['certThumbprint'])
+end
+
+def exist?
+  !@current_resource.nil?
+end
+
+def shared_url?
+  registry_get_subkeys(Chef::Resource::WinrmConfigListener.LISTENER_KEY).select do |key|
+    next unless key.end_with? new_resource.transport.to_s
+
+    values = registry_hash_values "#{Chef::Resource::WinrmConfigListener.LISTENER_KEY}\\#{key}"
+    new_resource.port == values['Port'] && new_resource.url_prefix == values['uriprefix']
+  end.count > 1
+end
+
+def registry_hash_values(key)
+  Hash[registry_get_values(key).map { |elt| [elt[:name], elt[:data]] }]
+end
+
+def url_acl_changed?
+  [:address, :port].any? do |attribute|
+    @new_resource.send(attribute) != @current_resource.send(attribute)
+  end
+end
+
+def ssl_binding_changed?
+  [:certificate_thumbprint, :address, :port].any? do |attribute|
+    @new_resource.send(attribute) != @current_resource.send(attribute)
+  end
+end
+
 action :configure do
+  if exist?
+    execute "Remove former URI binding #{current_resource.uri}" do
+      command "netsh http delete urlacl url=#{current_resource.uri}"
+      only_if { url_acl_changed? }
+      only_if "netsh http show urlacl url=#{current_resource.uri}"
+    end
+
+    execute "Remove former ssl certificate for #{current_resource.ip}:#{current_resource.port}" do
+      command "netsh http delete sslcert ipport=#{current_resource.ip}:#{current_resource.port}"
+      only_if { new_resource.transport == :HTTPS && ssl_binding_changed? }
+      only_if "netsh http show sslcert ipport=#{current_resource.ip}:#{current_resource.port}"
+    end
+  end
+
+  execute "Bind listener to winrm URI (url=#{new_resource.uri} SDDL=#{WINRM_SDDL})" do
+    command "netsh http add urlacl url=#{new_resource.uri} SDDL=#{WINRM_SDDL}"
+    only_if { !exist? || url_acl_changed? }
+    not_if "netsh http show urlacl url=#{new_resource.uri}"
+  end
+
+  execute "Bind ssl certificate to winrm listener #{new_resource.ip}:#{new_resource.port}" do
+    command "netsh http add sslcert ipport=#{new_resource.ip}:#{new_resource.port} certhash=#{new_resource.certificate_thumbprint} appid=#{WINRM_APPID}"
+    only_if { new_resource.transport == :HTTPS &&  (!exist? || ssl_binding_changed?) }
+    not_if "netsh http show sslcert ipport=#{new_resource.ip}:#{new_resource.port}"
+  end
+
   registry_key new_resource.key_name do
     action    :create
     recursive true
@@ -39,7 +111,26 @@ action :configure do
 end
 
 action :delete do
+  if exist?
+    execute "Remove URI binding #{new_resource.uri}" do
+      command "netsh http delete urlacl url=#{new_resource.uri}"
+      not_if { shared_url? }
+      only_if "netsh http show urlacl url=#{new_resource.uri}"
+    end
+
+    execute "Remove ssl certificate for #{new_resource.ip}:#{new_resource.port}" do
+      command "netsh http delete sslcert ipport=#{new_resource.ip}:#{new_resource.port}"
+      only_if { new_resource.transport == :HTTPS }
+      only_if "netsh http show sslcert ipport=#{new_resource.ip}:#{new_resource.port}"
+    end
+  end
+
   registry_key new_resource.key_name do
     action    :delete
   end
 end
+
+private
+
+WINRM_APPID = '{afebb9ad-9b97-4a91-9ab5-daf4d59122f6}'
+WINRM_SDDL = 'D:(A;;GX;;;S-1-5-80-569256582-2953403351-2909559716-1301513147-412116970)(A;;GX;;;S-1-5-80-4059739203-877974739-1245631912-527174227-2996563517)'

--- a/resources/listener.rb
+++ b/resources/listener.rb
@@ -29,6 +29,16 @@ attribute :port,                   default: 5985,    kind_of: Fixnum
 attribute :transport,              default: :HTTP,   kind_of: Symbol, equal_to: [:HTTP, :HTTPS]
 attribute :url_prefix,             default: 'wsman', kind_of: String
 
+LISTENER_KEY = 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WSMAN\Listener'
+
 def key_name
-  @key ||= "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\WSMAN\\Listener\\#{address}+#{transport}"
+  @key ||= "#{LISTENER_KEY}\\#{address}+#{transport}"
+end
+
+def ip
+  @ip ||= address[/^IP:(.*)$/i, 1] || '0.0.0.0'
+end
+
+def uri
+  @uri ||= "#{transport.to_s.downcase}://+:#{port}/#{url_prefix}/"
 end

--- a/resources/listener.rb
+++ b/resources/listener.rb
@@ -26,7 +26,7 @@ attribute :certificate_thumbprint, default: '',      kind_of: String
 attribute :enabled,                default: true,    kind_of: [TrueClass, FalseClass]
 attribute :hostname,               default: '',      kind_of: String
 attribute :port,                   default: 5985,    kind_of: Fixnum
-attribute :transport,              default: :HTTP,   kind_of: Symbol, equal_to: [:HTTP, :HTTPS]
+attribute :transport,              default: :HTTP,   kind_of: [String, Symbol], equal_to: ['HTTP', 'HTTPS', :HTTP, :HTTPS]
 attribute :url_prefix,             default: 'wsman', kind_of: String
 
 LISTENER_KEY = 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WSMAN\Listener'

--- a/spec/providers/listener_spec.rb
+++ b/spec/providers/listener_spec.rb
@@ -1,13 +1,16 @@
 require 'spec_helper'
 
 describe 'winrm_config_listener' do
-
   describe 'action create' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(step_into: ['winrm_config_listener']).converge('winrm-config-test::configure_listener')
     end
 
-    it 'create listener registry key' do
+    before do
+      stub_command('netsh http show urlacl url=http://+:5985/wsman/').and_return true
+    end
+
+    it 'creates listener registry key' do
       expect(chef_run).to configure_winrm_config_listener('configure_listener')
       expect(chef_run).to create_registry_key('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WSMAN\Listener\*+HTTP')
     end
@@ -18,7 +21,7 @@ describe 'winrm_config_listener' do
       ChefSpec::SoloRunner.new(step_into: ['winrm_config_listener']).converge('winrm-config-test::delete_listener')
     end
 
-    it 'delete listener registry key' do
+    it 'deletes listener registry key' do
       expect(chef_run).to delete_winrm_config_listener('delete_listener')
       expect(chef_run).to delete_registry_key('HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WSMAN\Listener\*+HTTPS')
     end


### PR DESCRIPTION
Handle properly WinRM listener
- update http urlacl
- update http sslcert

Allow listener transport to be a string
