### PR TITLE
Use windows_http_acl everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Configure WinRM service and client.
 
 Requirements
 ------------
-This cookbook requires Chef 11.10.0+.
+This cookbook requires Chef 12.1+ and the windows cookbook v2.10.
 
 ### Platforms
 This cookbook only supports the following platforms:

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,4 +6,5 @@ description      'Configures winrm service and client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.2.4'
 supports         'windows', '>= 6.0'
-depends          'windows', '>= 1.38'
+depends          'windows', '>= 2.1'
+chef_version     '>= 12.1' if respond_to?(:chef_version)

--- a/providers/listener.rb
+++ b/providers/listener.rb
@@ -88,13 +88,8 @@ action :configure do
     end
   end
 
-  # windows_http_acl does not handle SDDL
-  execute "Bind listener to winrm URI (url=#{new_resource.uri} SDDL=#{WINRM_SDDL})" do
-    command <<-EOS
-netsh http delete urlacl url=#{new_resource.uri}
-netsh http add urlacl url=#{new_resource.uri} SDDL=#{WINRM_SDDL}
-    EOS
-    not_if "netsh http show urlacl url=#{new_resource.uri} | FindStr #{new_resource.uri}"
+  windows_http_acl new_resource.uri do
+    sddl WINRM_SDDL
   end
 
   windows_certificate_binding "Bind ssl certificate to winrm listener #{new_resource.ip}:#{new_resource.port}" do


### PR DESCRIPTION
Since v2.1.0 windows cookbook handle SDDL in windows_http_acl.
Use it in the winrm_config_listener resource.
winrm-config now requires Chef 12.1+ and windows cookbook 2.1+.

*Cc.* @aboten, @criteo-cookbooks/sre-core 