### PR TITLE
Add run_as_user to service resource to work on Chef 14

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -40,5 +40,5 @@ registry_key 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WSMAN\Client' do
     { name: 'trusted_hosts',      type: :string, data: client_conf['TrustedHosts'] },
     { name: 'url_prefix',         type: :string, data: client_conf['URLPrefix'] },
   ]
-  notifies :restart, 'service[WinRM]', :delayed
+  notifies :restart, 'windows_service[WinRM]', :delayed
 end

--- a/recipes/listeners.rb
+++ b/recipes/listeners.rb
@@ -32,6 +32,6 @@ node['winrm_config']['listeners'].each do |key, conf|
     port                       conf['Port']
     transport                  conf['Transport']
     url_prefix                 conf['URLPrefix']
-    notifies :restart, 'service[WinRM]', :delayed
+    notifies :restart, 'windows_service[WinRM]', :delayed
   end
 end

--- a/recipes/protocol.rb
+++ b/recipes/protocol.rb
@@ -32,5 +32,5 @@ registry_key 'Setting up winrm protocol' do
     { name: 'timeout',        type: :dword, data: protocol_conf['MaxTimeoutms'] },
     { name: 'batch_maxItems', type: :dword, data: protocol_conf['MaxBatchItems'] },
   ]
-  notifies :restart, 'service[WinRM]', :delayed
+  notifies :restart, 'windows_service[WinRM]', :delayed
 end

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -44,5 +44,5 @@ registry_key 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WSMAN\Service' do
     { name: 'maxPacketRetrievalTime',         type: :dword,  data: service_conf['MaxPacketRetrievalTimeSeconds'] },
     { name: 'rootSDDL',                       type: :string, data: service_conf['RootSDDL'] },
   ]
-  notifies :restart, 'service[WinRM]', :delayed
+  notifies :restart, 'windows_service[WinRM]', :delayed
 end

--- a/recipes/windows_service.rb
+++ b/recipes/windows_service.rb
@@ -20,7 +20,7 @@
 
 return unless platform? 'windows'
 
-service 'WinRM' do
+windows_service 'WinRM' do
   run_as_user 'NT AUTHORITY\NetworkService'
   action [:enable, :start]
 end

--- a/recipes/windows_service.rb
+++ b/recipes/windows_service.rb
@@ -21,5 +21,6 @@
 return unless platform? 'windows'
 
 service 'WinRM' do
+  run_as_user 'NT AUTHORITY\NetworkService'
   action [:enable, :start]
 end

--- a/recipes/winrs.rb
+++ b/recipes/winrs.rb
@@ -35,5 +35,5 @@ registry_key 'Setting up winrs' do
     { name: 'MaxMemoryPerShellMB',    type: :dword, data: winrs_conf['MaxMemoryPerShellMB'] },
     { name: 'MaxShellsPerUser',       type: :dword, data: winrs_conf['MaxShellsPerUser'] },
   ]
-  notifies :restart, 'service[WinRM]', :delayed
+  notifies :restart, 'windows_service[WinRM]', :delayed
 end


### PR DESCRIPTION
On Chef 14 `windows_service` resource defaults to `LocalSystem` as a user account. So explicitly set user parameter to bypass user mismatch as WinRM uses `NetworkService` account.

Signed-off-by: Anton Kvashenkin anton.jugatsu@gmail.com

Closes #14 

- [x] Tested on Chef 13.10.4

- [x] Tested on Chef 14.5.33