### PR TITLE
Fix foodcritic violation for Chef 12 version

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,11 @@
 require 'rspec/core/rake_task'
 require 'foodcritic'
 
-FoodCritic::Rake::LintTask.new
+FoodCritic::Rake::LintTask.new do |fc|
+  # TODO: update following lines once we remove Chef 12 support
+  fc.options[:chef_version] = '12.1'
+  fc.options[:tags] = %w(~FC113)
+end
 RSpec::Core::RakeTask.new(:rspec)
 
 task default: [:foodcritic, :rspec]

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,12 @@
 name             'winrm-config'
 maintainer       'Criteo'
 maintainer_email 'b.courtois@criteo.com'
-license          'Apache 2.0'
+license          'Apache-2.0'
 description      'Configures winrm service and client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.2.4'
 supports         'windows', '>= 6.0'
 depends          'windows', '>= 2.1'
 chef_version     '>= 12.1' if respond_to?(:chef_version)
+issues_url       'https://github.com/criteo-cookbooks/winrm-config/issues' if respond_to?(:issues_url)
+source_url       'https://github.com/criteo-cookbooks/winrm-config' if respond_top?(:source_url)

--- a/providers/service_certmapping.rb
+++ b/providers/service_certmapping.rb
@@ -49,7 +49,6 @@ action :configure do
         content  password_hash
       end
     end
-    @new_resource.updated_by_last_action true
   end
 end
 
@@ -58,7 +57,6 @@ action :delete do
     converge_by 'deleting WinRM service certificate mapping' do
       winrm_delete
     end
-    @new_resource.updated_by_last_action true
   end
 end
 


### PR DESCRIPTION
Update the Rakefile to use Chef 12 compatible foodcritic rules.
Fix violations in metadata.
Remove useless use of updated_by_last_action since we use converge_by.