### PR TITLE
Make LWRPs compatible with Chef13

### DIFF
--- a/providers/listener.rb
+++ b/providers/listener.rb
@@ -29,7 +29,7 @@ end
 def load_current_resource
   return unless registry_key_exists? new_resource.key_name
 
-  @current_resource = Chef::Resource::WinrmConfigListener.new(new_resource.name, run_context)
+  @current_resource = ::Chef::Resource::resource_for_node(:winrm_config_listener, node).new(new_resource.name, run_context)
   @current_resource.address new_resource.address
   @current_resource.transport new_resource.transport
 

--- a/providers/service_certmapping.rb
+++ b/providers/service_certmapping.rb
@@ -26,7 +26,7 @@ end
 def load_current_resource
   winrm_data = winrm_get
   unless winrm_data.nil? || winrm_data.empty?
-    @current_resource = Chef::Resource::WinrmConfigServiceCertmapping.new(new_resource.name, run_context)
+    @current_resource = ::Chef::Resource.resource_for(:winrm_config_service_certmapping, node).new(new_resource.name, run_context)
     @current_resource.hydrate winrm_data
   end
 rescue => e


### PR DESCRIPTION
Since Chef 13 there is no more module constants for LWRPs.
We need to use ::Chef::Resource.resource_for_node.

Fix #13 