### PR TITLE
Add attribute to toggle service restart on winrm config changes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,6 +20,9 @@
 
 return unless platform? 'windows'
 
+# Allow to configure automatic restart of the winrm service on configuration change
+default['winrm_config']['restart_winrm_on_change']  = true
+
 # Below attributes follow the msdn default values
 # see https://msdn.microsoft.com/library/aa384372
 

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -40,5 +40,5 @@ registry_key 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WSMAN\Client' do
     { name: 'trusted_hosts',      type: :string, data: client_conf['TrustedHosts'] },
     { name: 'url_prefix',         type: :string, data: client_conf['URLPrefix'] },
   ]
-  notifies :restart, 'windows_service[WinRM]', :delayed
+  notifies :restart, 'windows_service[WinRM]', :delayed if node['winrm_config']['restart_winrm_on_change']
 end

--- a/recipes/listeners.rb
+++ b/recipes/listeners.rb
@@ -32,6 +32,6 @@ node['winrm_config']['listeners'].each do |key, conf|
     port                       conf['Port']
     transport                  conf['Transport']
     url_prefix                 conf['URLPrefix']
-    notifies :restart, 'windows_service[WinRM]', :delayed
+    notifies :restart, 'windows_service[WinRM]', :delayed if node['winrm_config']['restart_winrm_on_change']
   end
 end

--- a/recipes/protocol.rb
+++ b/recipes/protocol.rb
@@ -32,5 +32,5 @@ registry_key 'Setting up winrm protocol' do
     { name: 'timeout',        type: :dword, data: protocol_conf['MaxTimeoutms'] },
     { name: 'batch_maxItems', type: :dword, data: protocol_conf['MaxBatchItems'] },
   ]
-  notifies :restart, 'windows_service[WinRM]', :delayed
+  notifies :restart, 'windows_service[WinRM]', :delayed if node['winrm_config']['restart_winrm_on_change']
 end

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -44,5 +44,5 @@ registry_key 'HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\WSMAN\Service' do
     { name: 'maxPacketRetrievalTime',         type: :dword,  data: service_conf['MaxPacketRetrievalTimeSeconds'] },
     { name: 'rootSDDL',                       type: :string, data: service_conf['RootSDDL'] },
   ]
-  notifies :restart, 'windows_service[WinRM]', :delayed
+  notifies :restart, 'windows_service[WinRM]', :delayed if node['winrm_config']['restart_winrm_on_change']
 end

--- a/recipes/winrs.rb
+++ b/recipes/winrs.rb
@@ -35,5 +35,5 @@ registry_key 'Setting up winrs' do
     { name: 'MaxMemoryPerShellMB',    type: :dword, data: winrs_conf['MaxMemoryPerShellMB'] },
     { name: 'MaxShellsPerUser',       type: :dword, data: winrs_conf['MaxShellsPerUser'] },
   ]
-  notifies :restart, 'windows_service[WinRM]', :delayed
+  notifies :restart, 'windows_service[WinRM]', :delayed if node['winrm_config']['restart_winrm_on_change']
 end


### PR DESCRIPTION
In certain case (kitchen?) you might need to not restart WinRM service during chef run. You can now do that by setting the new attribute to false.