### PR TITLE
Protect windows_http_acl call

### DIFF
--- a/spec/providers/listener_spec.rb
+++ b/spec/providers/listener_spec.rb
@@ -20,6 +20,9 @@ describe 'winrm_config_listener' do
 
     before do
       stub_command('netsh http show urlacl url=http://+:5985/wsman/ | FindStr http://+:5985/wsman/').and_return true
+      stubs_for_provider("winrm_config_listener[configure_listener]") do |provider|
+        allow(provider).to receive_shell_out("netsh.exe http show urlacl url=HTTP://+:5985/wsman/")
+      end
     end
 
     it 'creates listener registry key' do


### PR DESCRIPTION
* Versions of windows_http_acl in windows cookbook < 5.2.2 are not
  idempotent
* While we can't force every users to bump windows cookbook, we can
  backport the fix in this resource

Change-Id: I45e6ea51d81bc033e613be6dfffaae68482ba545